### PR TITLE
Added options when retrieving tags

### DIFF
--- a/eip.py
+++ b/eip.py
@@ -149,12 +149,11 @@ class PLC:
     def GetProgramsList(self):
         '''
         Retrieves a program names list from the PLC
-        NB: Need to call GetTagList() first for this list to be generated!
-        Calling GetTagList() with default parameter of False will be faster,
-        since it only pulls controller tags including program names.
+        Sanity check: checks if programNames is empty
+        and runs _getTagList
         '''
         if not programNames:
-            return None
+            _getTagList(self)
         return programNames
 
     def Discover(self):


### PR DESCRIPTION
 

## Changes

 - Modified GetTagList() with new default parameter
 - New function GetProgramTagList(programName)
 - New function GetProgramTagList()

**Basic Usage**

    controller_tags = comm.GetTagList()
    all_tags = comm.GetTagList(True)
    one_program_tags = comm.GetProgramTagList('Program:MyProgram')
    program_names = comm.GetProgramList()

The only issue I ran into was with GetProgramTagList(programName):
If a wrong program string is given it will raise an exception, so need to figure out how to handle that gracefully without crashing the program. I'll take a look whenever I can and push another commit to this PR. Or maybe you have an idea already on how to handle it.

Also there might be a quicker way to get programs list without calling GetTagList() but in the grand scheme of things, must programs aren't that large that calling GetTagList() shouldn't take long to retrieve programNames.
