### PR TITLE
Do not fail when reading non-existent tags

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,7 @@
+13/06/19
+  -Fixed reading a list of a single item
+  -Do not fail when reading one or more tags that do not exist in the PLC
+
 05/31/19
   -Fixed connection parameters that cause Micro8xx to fail forwrad open
 

--- a/pylogix/__init__.py
+++ b/pylogix/__init__.py
@@ -1,4 +1,4 @@
 from .lgxDevice import LGXDevice
 from .eip import PLC
-__version_info__ = (0, 3, 4)
+__version_info__ = (0, 3, 5)
 __version__ = '.'.join(str(x) for x in __version_info__)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
     
 setuptools.setup(
     name="pylogix",
-    version="0.3.4",
+    version="0.3.5",
     author="Dustin Roeder",
     author_email="dmroeder@gmail.com",
     description="Read/Write Rockwell Automation Logix based PLC's",


### PR DESCRIPTION
I propose this patch, in case you're interested (I need this behavior for my application).
However, it can break some implementations that would use the fact that a Read or MultiRead returns an exception if a tag cannot be read, since in my case it just returns `None`.