### PR TITLE
#68 — fix GetTagList() AttributeError

### DIFF
--- a/pylogix/eip.py
+++ b/pylogix/eip.py
@@ -124,7 +124,7 @@ class PLC:
         otherwise controller tags and program tags.
         '''
         tag_list = self._getTagList(allTags)
-        updated_list = self._getUDT(tag_list.value)
+        updated_list = self._getUDT(tag_list.Value)
         
         return Response(None, updated_list, tag_list.status)
 

--- a/pylogix/eip.py
+++ b/pylogix/eip.py
@@ -126,7 +126,7 @@ class PLC:
         tag_list = self._getTagList(allTags)
         updated_list = self._getUDT(tag_list.Value)
         
-        return Response(None, updated_list, tag_list.status)
+        return Response(None, updated_list, tag_list.Status)
 
     def GetProgramTagList(self, programName):
         '''


### PR DESCRIPTION
Line 127 is looking for a lowercase “value” when the Response object used by `self._getTagList` is a capitalized “Value”. Changing this to a capital V fixes it (from my testing) and allows it to find the Value to process into `self._getUDT`