### PR TITLE
#70 GetProgramsList, and GetProgramTagList

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+09/23/19
+  - Addressed GetProgramsList and GetProgramTagList issues. (FAB)
+
 09/18/19
   -Changed the case of Response to match the rest of the project, minimizing the impact of the new change
 

--- a/changelog
+++ b/changelog
@@ -1,5 +1,8 @@
-09/23/19
-  - Addressed GetProgramsList and GetProgramTagList issues. (FAB)
+09/23/19 - kodaman2
+  - Addressed GetProgramsList and GetProgramTagList issues.
+
+09/23/19 - ambersnow
+  - Fixed GetTagList() AtributeError
 
 09/18/19
   -Changed the case of Response to match the rest of the project, minimizing the impact of the new change

--- a/pylogix/__init__.py
+++ b/pylogix/__init__.py
@@ -1,4 +1,4 @@
 from .lgxDevice import LGXDevice
 from .eip import PLC
-__version_info__ = (0, 4, 0)
+__version_info__ = (0, 4, 2)
 __version__ = '.'.join(str(x) for x in __version_info__)

--- a/pylogix/eip.py
+++ b/pylogix/eip.py
@@ -134,14 +134,14 @@ class PLC:
         programName = "Program:ExampleProgram"
         '''
 
+        # If ProgramNames is empty then _getTagList hasn't been called
         if not self.ProgramNames:
-            tags = self._getTagList(False)
+            self._getTagList(False)
         
-        # Get a single program tags if progragName exists
+        # Get single program tags if progragName exists
         if programName in self.ProgramNames:
             program_tags = self._getProgramTagList(programName)
-            program_tags = self._getUDT(program_tags[1])
-            return Response(None, program_tags, tags[2])
+            return Response(None, program_tags.Value, program_tags.Status)
         else:
             return Response(None, None, 'Program not found, please check name!')
 
@@ -152,8 +152,8 @@ class PLC:
         and runs _getTagList
         '''
         if not self.ProgramNames:
-            tag_list = self._getTagList(True)
-        return Response(None, self.ProgramNames, tag_list[2])
+            self._getTagList(False)
+        return Response(None, self.ProgramNames, 'Success')
 
     def Discover(self):
         '''


### PR DESCRIPTION
This addresses issue: #70 

Why was this change made?
Both functions were returning runtime exceptions due to incorrect parameters on the return Response object.

How does it address the issue?
It gets rid of runtime exceptions, and returns program tags and programs list properly.

	modified:   pylogix/eip.py

Details:

### GetProgramsList 
On GetProgramsList for example we only call `_self._getTagList` to update `self.ProgramNames` if is empty, if is not then it goes straight to the return call which can be troublesome. So if we were using tag_list it would have been tag_list.Status anyways but I left it simple with a given string of `Success`.

### GetProgramTagList 
On GetProgramTagList is along the same lines with the call to  `_self._getTagList`. The only tags that we worry about are specific to the return on `self._getProgramTagList`. I also removed the `_getUDT` call because is not needed for this function at all.