### PR TITLE
_writeTag-fix-patch Exception error

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,8 +1,11 @@
 09/25/19 - kodaman2
+  - Fixed _writeTag to non existent tags exception error
+
+09/25/19 - kodaman2
   - Updated README with old installation instructions
 
 09/23/19 - kodaman2
-  - Addressed GetProgramsList and GetProgramTagList issues.
+  - Addressed GetProgramsList and GetProgramTagList issues
 
 09/23/19 - ambersnow
   - Fixed GetTagList() AtributeError

--- a/pylogix/__init__.py
+++ b/pylogix/__init__.py
@@ -1,4 +1,4 @@
 from .lgxDevice import LGXDevice
 from .eip import PLC
-__version_info__ = (0, 4, 3)
+__version_info__ = (0, 4, 4)
 __version__ = '.'.join(str(x) for x in __version_info__)

--- a/pylogix/eip.py
+++ b/pylogix/eip.py
@@ -230,7 +230,7 @@ class PLC:
         t,b,i = _parseTagName(tag, 0)
         resp = self._initial_read(t, b, dt)
         if resp[2] != 0 and resp[2] != 6:
-            return Response(tag, None, status)
+            return Response(tag, None, resp[2])
 
         dataType = self.KnownTags[b][0]
 

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@ import setuptools
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
-    
+
 setuptools.setup(
     name="pylogix",
-    version="0.4.3",
+    version="0.4.4",
     author="Dustin Roeder",
     author_email="dmroeder@gmail.com",
     description="Read/Write Rockwell Automation Logix based PLC's",
@@ -19,5 +19,5 @@ setuptools.setup(
         "Programming Language :: Python :: 3.6",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
-        ],
-    )
+    ],
+)


### PR DESCRIPTION
Ok, I think we are out of the woods now. Should be the last remaining small bug.

While I was writing the unittest test for trying to read/write to non existent tags. I found that `status` was not declared prior to being used, after a little debugging I just changed it to `resp[2]` to get the status just like the _readTag function. Passed all the unittests.  🎉 