### PR TITLE
get_error_codes patch

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+09/27/19 - kodaman2
+  - Modified to return correct return status, when nesting Response.Status to another Response object
+
 09/25/19 - kodaman2
   - Path for GetProgramTagList to return LGXTag properly
 

--- a/pylogix/__init__.py
+++ b/pylogix/__init__.py
@@ -1,4 +1,4 @@
 from .lgxDevice import LGXDevice
 from .eip import PLC
-__version_info__ = (0, 4, 5)
+__version_info__ = (0, 4, 6)
 __version__ = '.'.join(str(x) for x in __version_info__)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pylogix",
-    version="0.4.5",
+    version="0.4.6",
     author="Dustin Roeder",
     author_email="dmroeder@gmail.com",
     description="Read/Write Rockwell Automation Logix based PLC's",


### PR DESCRIPTION
Modified the way the error status is returned, because Response is nested in some places. Is outputting conflicting information:

Before fix:
```
Response(None, tags.Value, tags.Status)
output: Unknown error Success
```

After fix:
```
Response(None, tags.Value, tags.Status)
output: Success
```

Tested in both py2, py3.