### PR TITLE
fixed-status-programList

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,7 @@
 09/27/19 - kodaman2
+  - Fixed Multiple paths for status on GetProgramsList
+
+09/27/19 - kodaman2
   - Modified to return correct return status, when nesting Response.Status to another Response object
 
 09/25/19 - kodaman2

--- a/pylogix/__init__.py
+++ b/pylogix/__init__.py
@@ -1,4 +1,4 @@
 from .lgxDevice import LGXDevice
 from .eip import PLC
-__version_info__ = (0, 4, 6)
+__version_info__ = (0, 4, 7)
 __version__ = '.'.join(str(x) for x in __version_info__)

--- a/pylogix/eip.py
+++ b/pylogix/eip.py
@@ -155,9 +155,16 @@ class PLC:
         Sanity check: checks if programNames is empty
         and runs _getTagList
         '''
+        tags = ''
         if not self.ProgramNames:
             tags = self._getTagList(False)
-        return Response(None, self.ProgramNames, tags.Status)
+        if tags:
+            status = tags.Status
+        if self.ProgramNames:
+            status = 0
+        else:
+            status = "Unable to retrieve programs list"
+        return Response(None, self.ProgramNames, status)
 
     def Discover(self):
         '''

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pylogix",
-    version="0.4.6",
+    version="0.4.7",
     author="Dustin Roeder",
     author_email="dmroeder@gmail.com",
     description="Read/Write Rockwell Automation Logix based PLC's",


### PR DESCRIPTION
This updates ensures GetProgramList either gets status from _getTagsList or self.ProgramNames, if both are empty, then it will return proper error. This should never happen unless there are 0 programs but I don't think that is possible.

It is possible to not retrieve tags, in that case error will be given since programs are inside controller tags list.

```
Unable to retrieve programs list
```