### PR TITLE
Fix 'raw' option in iep.py for _GetPLCTime & example 21

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,7 @@
+04/05/20
+  - Fix raw return for GetPLCTime
+  - Fix printed return for example 21
+  
 04/23/20
   - jprogin's enhancements (read large lists, save UDT)
   - Fixes for making too many requests for templates already known

--- a/changelog
+++ b/changelog
@@ -1,4 +1,4 @@
-04/05/20
+05/04/20
   - Fix raw return for GetPLCTime
   - Fix printed return for example 21
   

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -4,25 +4,35 @@
 
 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 
-- [ ] Bug fix (non-breaking change which fixes an issue)
+- [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 - [ ] I have read the **docs/CONTRIBUTING.md** document.
-- [ ] My code follows the code style of this project.
+- [X] My code follows the code style of this project.
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
-- [ ] I have read **tests/README.md**.
+- [X] I have read **tests/README.md**.
 - [ ] I have added tests to cover my changes.
 - [ ] All new and existing tests passed.
 
 ## What is the change?
+Added misssing esle statement in eip.py / _getPLCTime
+-> raw option didn't work
+Modified print details in example 21_get_plc_clock.py
+-> Wrong returned objects
 
 ## What does it fix/add?
+Raw value for getting PLC time works now
+No more error when using example 21_get_plc_clock.py
 
 ## Test Configuration
-
 - PLC Model
+Compact Logix L35E & ControlLogix L82E
 - PLC Firmware
+20.011 & Unknow
 - pylogix version
 - python version
+3.7.3
 - OS type and version
+Raspberrypi raspbian10
+Windows 10

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -4,35 +4,25 @@
 
 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 
-- [X] Bug fix (non-breaking change which fixes an issue)
+- [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 - [ ] I have read the **docs/CONTRIBUTING.md** document.
-- [X] My code follows the code style of this project.
+- [ ] My code follows the code style of this project.
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
-- [X] I have read **tests/README.md**.
+- [ ] I have read **tests/README.md**.
 - [ ] I have added tests to cover my changes.
 - [ ] All new and existing tests passed.
 
 ## What is the change?
-Added misssing esle statement in eip.py / _getPLCTime
--> raw option didn't work
-Modified print details in example 21_get_plc_clock.py
--> Wrong returned objects
 
 ## What does it fix/add?
-Raw value for getting PLC time works now
-No more error when using example 21_get_plc_clock.py
 
 ## Test Configuration
+
 - PLC Model
-Compact Logix L35E & ControlLogix L82E
 - PLC Firmware
-20.011 & Unknow
 - pylogix version
 - python version
-3.7.3
 - OS type and version
-Raspberrypi raspbian10
-Windows 10

--- a/examples/21_get_plc_clock.py
+++ b/examples/21_get_plc_clock.py
@@ -13,6 +13,7 @@ from pylogix import PLC
 
 with PLC() as comm:
     comm.IPAddress = '192.168.1.9'
+    ret = comm.GetPLCTime()
     time_value = ret.Value
 
     # print the Response value

--- a/examples/21_get_plc_clock.py
+++ b/examples/21_get_plc_clock.py
@@ -13,7 +13,19 @@ from pylogix import PLC
 
 with PLC() as comm:
     comm.IPAddress = '192.168.1.9'
-    ret = comm.GetPLCTime()
+    time_value = ret.Value
 
-    # print each pice of time
-    print(ret.TagName, ret.Value, ret.Status)
+    # print the Response value
+    print(ret)
+
+    # print the whole value
+    print(time_value)
+
+    # print each piece of time
+    print(time_value.year,
+          time_value.month,
+          time_value.day,
+          time_value.hour,
+          time_value.minute,
+          time_value.second,
+          time_value.microsecond)

--- a/examples/21_get_plc_clock.py
+++ b/examples/21_get_plc_clock.py
@@ -15,7 +15,5 @@ with PLC() as comm:
     comm.IPAddress = '192.168.1.9'
     ret = comm.GetPLCTime()
 
-    # print the whole value
-    print(ret.Value)
     # print each pice of time
-    print(ret.year, ret.month, ret.day, ret.hour, ret.minute, ret.second, ret.microsecond)
+    print(ret.TagName, ret.Value, ret.Status)

--- a/pylogix/__init__.py
+++ b/pylogix/__init__.py
@@ -1,4 +1,4 @@
 from .lgxDevice import LGXDevice
 from .eip import PLC
-__version_info__ = (0, 6, 7)
+__version_info__ = (0, 6, 8)
 __version__ = '.'.join(str(x) for x in __version_info__)

--- a/pylogix/eip.py
+++ b/pylogix/eip.py
@@ -510,8 +510,9 @@ class PLC:
             plc_time = unpack_from('<Q', ret_data, 56)[0]
             if raw:
                 value = plc_time
-            human_time = datetime(1970, 1, 1) + timedelta(microseconds=plc_time)
-            value = human_time
+            else:
+                human_time = datetime(1970, 1, 1) + timedelta(microseconds=plc_time)
+                value = human_time
         else:
             value = None
 


### PR DESCRIPTION
Fix `_getPLCTime` in `eip.py` about 'raw' option
Fix example `21_get_plc_clock.py` witch gave a `print` error due to incorrect object called

## Short description of change

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **docs/CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read **tests/README.md**.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## What is the change?
Added misssing esle statement in `eip.py` => `_getPLCTime`
-> raw option didn't work
Modified print details in example `21_get_plc_clock.py`
-> Wrong returned objects

## What does it fix/add?
Raw value for getting PLC time works now
No more error when running example 21_get_plc_clock.py

## Test Configuration
- PLC Model
Compact Logix L35E & ControlLogix L82E
- PLC Firmware
20.011 & Unknow
- pylogix version
- python version
3.7.3
- OS type and version
Raspberrypi raspbian10
Windows 10