### PR TITLE
little-endian enhancement

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,7 @@
 05/13/20
+  - Force little endian to support pylogix import in jython as Java uses big-endian. Issue #132 
+
+05/13/20
   - Fixed PylogixTests.py imports
 
 05/11/20

--- a/pylogix/__init__.py
+++ b/pylogix/__init__.py
@@ -1,4 +1,4 @@
 #from .lgxDevice import LGXDevice
 from .eip import PLC
-__version_info__ = (0, 6, 9)
+__version_info__ = (0, 6, 10)
 __version__ = '.'.join(str(x) for x in __version_info__)

--- a/pylogix/eip.py
+++ b/pylogix/eip.py
@@ -63,20 +63,20 @@ class PLC:
         self.StructIdentifier = 0x0fCE
         self.StringEncoding = 'utf-8'
         self.CIPTypes = {0: (0, "UNKNOWN", '?'),
-                         160: (88, "STRUCT", 'B'),
+                         160: (88, "STRUCT", '<B'),
                          193: (1, "BOOL", '?'),
-                         194: (1, "SINT", 'b'),
-                         195: (2, "INT", 'h'),
-                         196: (4, "DINT", 'i'),
-                         197: (8, "LINT", 'q'),
-                         198: (1, "USINT", 'B'),
-                         199: (2, "UINT", 'H'),
-                         200: (4, "UDINT", 'I'),
-                         201: (8, "LWORD", 'Q'),
-                         202: (4, "REAL", 'f'),
-                         203: (8, "LREAL", 'd'),
-                         211: (4, "DWORD", 'I'),
-                         218: (1, "STRING", 'B')}
+                         194: (1, "SINT", '<b'),
+                         195: (2, "INT", '<h'),
+                         196: (4, "DINT", '<i'),
+                         197: (8, "LINT", '<q'),
+                         198: (1, "USINT", '<B'),
+                         199: (2, "UINT", '<H'),
+                         200: (4, "UDINT", '<I'),
+                         201: (8, "LWORD", '<Q'),
+                         202: (4, "REAL", '<f'),
+                         203: (8, "LREAL", '<d'),
+                         211: (4, "DWORD", '<I'),
+                         218: (1, "STRING", '<B')}
 
     def __enter__(self):
         return self


### PR DESCRIPTION
## Short description of change

Forcing little endian to support jython users

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x  ] New feature (non-breaking change which adds functionality)
- [ x  ] I have read **tests/README.md**.
- [ x  ] All new and existing tests passed.

## What is the change?
Explicit little endian on `self.CIPTypes` on `eip.py`

## What does it fix/add?
Fixes reverse endianness in jython so that pylogix can work.
