### PR TITLE
Support a specific PLC ConnectionSize for Connected sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ NOTE: If you are working with a Micro8xx PLC, you must set the Micro800 flag sin
 comm.Micro800 = True
 ```
 
+Optionally set a specific maximum size for requests/replies.  If not specified, defaults to try a Large, then a Small Forward Open (for Implicit, "Connected" sessions).
+
+```
+comm.ConnectionSize = 508
+```
+
+
 ### Other Features
 
 Pylogix has features other than simply reading/writing.  You can see all of them in the examples, I'll also list them here
@@ -86,6 +93,7 @@ Pylogix has features other than simply reading/writing.  You can see all of them
 * **Dustin Roeder** - *Maintainer* - [dmroeder](https://github.com/dmroeder)
 * **Fernando B.** - *Contributor* - [kodaman2](https://github.com/kodaman2)
 * **Ottowayi** - *Contributor* - [ottowayi](https://github.com/ottowayi)
+* **Perry Kundert** - *Contributor* - [pjkundert](https://github.com/pjkundert)
 
 ## License
 

--- a/pylogix/__init__.py
+++ b/pylogix/__init__.py
@@ -1,3 +1,3 @@
 from .eip import PLC
-__version_info__ = (0, 7, 5)
+__version_info__ = (0, 7, 6)
 __version__ = '.'.join(str(x) for x in __version_info__)

--- a/pylogix/eip.py
+++ b/pylogix/eip.py
@@ -44,7 +44,7 @@ class PLC:
         self.Route = None
 
         self.conn = Connection(self)
-        self.ConnectionSize = 508
+
         self.Offset = 0
         self.UDT = {}
         self.UDTByName = {}
@@ -68,6 +68,18 @@ class PLC:
                          203: (8, "LREAL", '<d'),
                          211: (4, "DWORD", '<i'),
                          218: (1, "STRING", '<B')}
+
+    @property
+    def ConnectionSize(self):
+        """Set the ConnectionSize before initiating the first call requiring conn.connect().  The
+        default behavior is to attempt a Large followed by a Small Forward Open.  If an Explicit
+        (Unconnected) session is used, picks a sensible default.
+
+        """
+        return self.conn.ConnectionSize or 508
+    @ConnectionSize.setter
+    def ConnectionSize(self, connection_size):
+        self.conn.ConnectionSize = connection_size
 
     def __enter__(self):
         return self


### PR DESCRIPTION
o Still defaults to issuing Large and then Small Forward Open requests
o PLC.ConnectionSize accesses underlying Connection.ConnectionSize

## Short description of change

Allow specification of PLC.ConnectionSize, to specify a certain Forward Open size; otherwise, default to try a Large, then a Small Forward Open (as it did previously).  API remains unchanged, except for adding the optional PLC.ConnectionSize specification.

Also, ensures that there is one ConnectionSize (in the Connection); uses a PLC property to access the underlying Connection.ConnectionSize.

Advanced to version 0.7.6.

## Types of changes

Unfortunately, I have no access to a C*Logix PLC, so could not run the test suite.  However, I have tested it against the https://github.com/pjkundert/cpppo.git project, and ensured that both Small and Large Forward Open works correctly.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x] I have read the **docs/CONTRIBUTING.md** document.
- [ x] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] I have read **tests/README.md**.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## What is the change?

## What does it fix/add?

## Test Configuration

- PLC Model
- PLC Firmware
- pylogix version
- python version
- OS type and version
