### PR TITLE
New Boolean tests

### DIFF
--- a/tests/PylogixTests.py
+++ b/tests/PylogixTests.py
@@ -284,6 +284,15 @@ class PylogixTests(unittest.TestCase):
         self.assertEqual(len(response), len(
             tags), 'Unable to read multiple tags!')
 
+        for i in range(len(response)):
+            self.assertEqual('Success', response[i].Status)
+
+    def bool_list_fixture(self, length=8):
+        bool_list = []
+        for i in range(length):
+            bool_list.append('BaseBOOLArray[{}]'.format(i))
+        return bool_list
+
     def setUp(self):
         comm.IPAddress = plcConfig.plc_ip
         comm.ProcessorSlot = plcConfig.plc_slot
@@ -315,6 +324,10 @@ class PylogixTests(unittest.TestCase):
 
     def test_multi_read(self):
         tags = ['BaseDINT', 'BaseINT', 'BaseSTRING']
+        self.multi_read_fixture(tags)
+
+    def test_bool_list(self):
+        tags = self.bool_list_fixture(128)
         self.multi_read_fixture(tags)
 
     def test_discover(self):


### PR DESCRIPTION
## Short description of change

I've added a new test fixture, which tests our current BaseBOOLArray[128]. Not sure what is going on yet, but feeding a list of boolean with more than 4 tags causes the rest to return Path destination unknown. I made the PR just in case we need to add more tests, I'll merge after #151 is complete if there are any bugs to be fixed.

## Types of changes

- [x ] I have added tests to cover my changes.

## What is the change?

This should help to test #151 
Here you can change it to anything below 128 since that's the size of BaseBOOLArray

```
    def test_bool_list(self):
        tags = self.bool_list_fixture(128)
        self.multi_read_fixture(tags)
```

## What does it fix/add?

A better unit test for testing boolean lists to ensure Status is successful.