### PR TITLE
Allow single and multi array tags be included in array of tags

### DIFF
--- a/examples/81_simple_gui.py
+++ b/examples/81_simple_gui.py
@@ -591,6 +591,8 @@ def startUpdateValue():
 
                         if not response[0].Value is None:
                             for i in range(0, len(response)):
+                                allValues += response[i].TagName + ' ~ '
+
                                 if (checkVarBoolDisplay.get() == 1) and (str(response[i].Value) == 'True' or str(response[i].Value) == 'False'):
                                     allValues += '1, ' if str(response[i].Value) == 'True' else '0, '
                                 else:
@@ -599,11 +601,15 @@ def startUpdateValue():
                                     else:
                                         allValues += str(response[i].Value) + ', '
 
+                                allValues += '\n'
+
                     if len(arrayTags) > 0:
                         for tg in arrayTags:
                             response = comm.Read(tg, arrayTags[tg])
 
                             if not response.Value is None:
+                                allValues += response.TagName + ' ~ '
+
                                 if (checkVarBoolDisplay.get() == 1) and (str(response.Value[0]) == 'True' or str(response.Value[0]) == 'False'):
                                     newBoolArray = []
                                     for val in range(0, len(response.Value)):
@@ -612,6 +618,8 @@ def startUpdateValue():
                                     allValues += str(newBoolArray) + ', '
                                 else:
                                     allValues += str(response.Value) + ', '
+
+                                allValues += '\n'
                 except Exception as e:
                     tagValue['text'] = str(e)
                     connected = False

--- a/examples/81_simple_gui.py
+++ b/examples/81_simple_gui.py
@@ -273,7 +273,7 @@ def main():
         fnt = tkfont.Font(family="Helvetica", size=11, weight="normal")
         char_width = fnt.measure("0")
     
-    tagValue = LabelResizing(frame5, text='~', fg='yellow', bg='navy', font='Helvetica 18', width=(int(800 / char_width - 4.5)), wraplength=800, relief=SUNKEN)
+    tagValue = LabelResizing(frame5, text='~', justify='left', fg='yellow', bg='navy', font='Helvetica 18', width=(int(800 / char_width - 4.5)), wraplength=800, relief=SUNKEN)
     tagValue.pack(anchor='center', padx=3, pady=5)
 
     # add a frame to hold the IPAddress / Slot labels
@@ -603,7 +603,7 @@ def startUpdateValue():
 
                         if not response[0].Value is None:
                             for i in range(0, len(response)):
-                                allValues += response[i].TagName + ' ~ '
+                                allValues += response[i].TagName + ' : '
 
                                 if (checkVarBoolDisplay.get() == 1) and (str(response[i].Value) == 'True' or str(response[i].Value) == 'False'):
                                     allValues += '1, ' if str(response[i].Value) == 'True' else '0, '
@@ -620,7 +620,7 @@ def startUpdateValue():
                             response = comm.Read(tg, arrayTags[tg])
 
                             if not response.Value is None:
-                                allValues += response.TagName + ' ~ '
+                                allValues += response.TagName + ' : '
 
                                 if (checkVarBoolDisplay.get() == 1) and (str(response.Value[0]) == 'True' or str(response.Value[0]) == 'False'):
                                     newBoolArray = []

--- a/examples/81_simple_gui.py
+++ b/examples/81_simple_gui.py
@@ -561,7 +561,7 @@ def startUpdateValue():
                                 try:
                                     arrayElementCount = int(t[t.index('{') + 1:t.index('}')])
 
-                                    if arrayElementCount <= 0:
+                                    if arrayElementCount < 2:
                                         regularTags.append(t[:t.index('{')])
                                     else:
                                         readArray = True
@@ -575,7 +575,7 @@ def startUpdateValue():
                     try:
                         arrayElementCount = int(displayTag[displayTag.index('{') + 1:displayTag.index('}')])
 
-                        if arrayElementCount <= 0:
+                        if arrayElementCount < 2:
                             regularTags.append(displayTag[:displayTag.index('{')])
                         else:
                             readArray = True

--- a/examples/81_simple_gui.py
+++ b/examples/81_simple_gui.py
@@ -574,8 +574,12 @@ def startUpdateValue():
                 elif displayTag.endswith('}') and '{' in displayTag: # 1 or 2 or 3 dimensional array tag
                     try:
                         arrayElementCount = int(displayTag[displayTag.index('{') + 1:displayTag.index('}')])
-                        readArray = True
-                        arrayTags.update( {displayTag[:displayTag.index('{')] : arrayElementCount} )
+
+                        if arrayElementCount <= 0:
+                            regularTags.append(displayTag[:displayTag.index('{')])
+                        else:
+                            readArray = True
+                            arrayTags.update( {displayTag[:displayTag.index('{')] : arrayElementCount} )
                     except:
                         regularTags.append(displayTag[:displayTag.index('{')])
                 else:


### PR DESCRIPTION
## Short description of change
Single or multi array tags, as well as bits of an element, can now be included in array of tags, example: CT_DINT; CT_REAL; CT_DINT.2{7}; CT_BOOLArray[0]{25}

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **docs/CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read **tests/README.md**.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## What is the change?
- Single or multi array tags, as well as bits of an element, can now be included in array of tags, example: CT_DINT; CT_REAL; CT_DINT.2{7}; CT_BOOLArray[0]{25}
- These arrays are using consecutive read requests
- Added extra description to the tags label suggesting to use semicolon as a tag separator
- Updated comments, some minor code changes and updated some error handling

## What does it fix/add?
- This is a sort of a convenience update with a new feature that was also included in the pylogix-api project

## Test Configuration

- PLC Model
- PLC Firmware
- pylogix version 0.7.10
- python version 2.7.18 & 3.6.8
- OS type and version Windows 10 v2004
