### PR TITLE
fix typo datatye in the read method example

### DIFF
--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -242,7 +242,7 @@ tags, it can speed things up.
 ```python
 from pylogix import PLC
 with PLC("192.168.1.9") as comm:
-    ret = comm.Read("MyDint", data_type=0xc4)
+    ret = comm.Read("MyDint", datatype=0xc4)
     print(ret.TagName, ret.Value, ret.Status)
 ```
 result:


### PR DESCRIPTION
## Short description of change
fix typo in documentation. The named parameter to Read() is datatype without underscore
## Types of changes

documentation only

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **docs/CONTRIBUTING.md** document.
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read **tests/README.md**.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## What is the change?
typo in documentation

## What does it fix/add?
none
## Test Configuration
none