### PR TITLE
Feature/add micro800 to plc init

### DIFF
--- a/pylogix/eip.py
+++ b/pylogix/eip.py
@@ -33,14 +33,14 @@ from struct import pack, unpack_from
 
 class PLC(object):
 
-    def __init__(self, ip_address="", slot=0, timeout=5.0,**kwargs):
+    def __init__(self, ip_address="", slot=0, timeout=5.0,Micro800=False):
         """
         Initialize our parameters
         """
         self.IPAddress = ip_address
         self.ProcessorSlot = slot
         self.SocketTimeout = timeout
-        self.Micro800 = kwargs.get('Micro800',False)
+        self.Micro800 = Micro800
         self.Route = None
 
         self.conn = Connection(self)

--- a/pylogix/eip.py
+++ b/pylogix/eip.py
@@ -33,14 +33,14 @@ from struct import pack, unpack_from
 
 class PLC(object):
 
-    def __init__(self, ip_address="", slot=0, timeout=5.0):
+    def __init__(self, ip_address="", slot=0, timeout=5.0,**kwargs):
         """
         Initialize our parameters
         """
         self.IPAddress = ip_address
         self.ProcessorSlot = slot
         self.SocketTimeout = timeout
-        self.Micro800 = False
+        self.Micro800 = kwargs.get('Micro800',False)
         self.Route = None
 
         self.conn = Connection(self)

--- a/pylogix/eip.py
+++ b/pylogix/eip.py
@@ -33,7 +33,7 @@ from struct import pack, unpack_from
 
 class PLC(object):
 
-    def __init__(self, ip_address="", slot=0, timeout=5.0,Micro800=False):
+    def __init__(self, ip_address="", slot=0, timeout=5.0, Micro800=False):
         """
         Initialize our parameters
         """
@@ -927,6 +927,8 @@ class PLC(object):
                                 devices.append(device)
                 except Exception:
                     pass
+                try: s.close()   ### Ensure socket is closed
+                except: pass
 
         # added this because looping through addresses above doesn't work on
         # linux so this is a "just in case".  If we don't get results with the
@@ -946,6 +948,8 @@ class PLC(object):
                             devices.append(device)
             except Exception:
                 pass
+            try: s.close()   ### Ensure socket is closed
+            except: pass
 
         return Response(None, devices, 0)
 

--- a/pylogix/lgx_comm.py
+++ b/pylogix/lgx_comm.py
@@ -85,6 +85,8 @@ class Connection(object):
                 return (True, 'Success')
 
         try:
+            try: self.Socket.close()    ### Ensure socket is closed
+            except: pass
             self.Socket = socket.socket()
             self.Socket.settimeout(self.parent.SocketTimeout)
             self.Socket.connect((self.parent.IPAddress, self.Port))

--- a/tests/PylogixTests.py
+++ b/tests/PylogixTests.py
@@ -299,12 +299,16 @@ class PylogixTests(unittest.TestCase):
         comm.Micro800 = plcConfig.isMicro800
 
     def test_basic(self):
+        try: assert plcConfig.skip_test_basic ; return
+        except: pass
         self.basic_fixture()
         self.basic_array_fixture()
         self.basic_fixture('PROGRAM:MainProgram.p')
         self.basic_array_fixture('PROGRAM:MainProgram.p')
 
     def test_udt(self):
+        try: assert plcConfig.skip_test_udt ; return
+        except: pass
         self.udt_basic_fixture()
         self.udt_array_fixture_01()
         self.udt_array_fixture_02()
@@ -313,37 +317,53 @@ class PylogixTests(unittest.TestCase):
         self.udt_array_fixture_02('PROGRAM:MainProgram.p')
 
     def test_combined(self):
+        try: assert plcConfig.skip_test_combined ; return
+        except: pass
         self.udt_combined_fixture()
         self.udt_combined_array_fixture()
         self.udt_combined_fixture('PROGRAM:MainProgram.p')
         self.udt_combined_array_fixture('PROGRAM:MainProgram.p')
 
     def test_array(self):
+        try: assert plcConfig.skip_test_array ; return
+        except: pass
         self.read_array_fixture()
         self.read_array_fixture('PROGRAM:MainProgram.p')
 
     def test_multi_read(self):
+        try: assert plcConfig.skip_test_multi_read ; return
+        except: pass
         tags = ['BaseDINT', 'BaseINT', 'BaseSTRING']
         self.multi_read_fixture(tags)
 
     def test_bool_list(self):
+        try: assert plcConfig.skip_test_bool_list ; return
+        except: pass
         tags = self.bool_list_fixture(128)
         self.multi_read_fixture(tags)
 
     def test_discover(self):
+        try: assert plcConfig.skip_test_discover ; return
+        except: pass
         devices = comm.Discover()
         self.assertEqual(devices.Status, 'Success', devices.Status)
 
     def test_time(self):
+        try: assert plcConfig.skip_test_time ; return
+        except: pass
         comm.SetPLCTime()
         time = comm.GetPLCTime()
         self.assertEqual(time.Status, 'Success', time.Status)
 
     def test_get_tags(self):
+        try: assert plcConfig.skip_test_get_tags ; return
+        except: pass
         tags = comm.GetTagList()
         self.assertGreater(len(tags.Value), 1, tags.Status)
 
     def test_unexistent_tags(self):
+        try: assert plcConfig.skip_test_unexistent_tags ; return
+        except: pass
         response = comm.Read('DumbTag')
         self.assertEqual(
             response.Status, 'Path segment error', response.Status)
@@ -352,12 +372,16 @@ class PylogixTests(unittest.TestCase):
             write_reponse.Status, 'Path segment error', write_reponse.Status)
 
     def test_lgx_tag_class(self):
+        try: assert plcConfig.skip_test_lgx_tag_class ; return
+        except: pass
         tags = comm.GetTagList()
         self.assertEqual(
             isinstance(
                 tags.Value[0], Tag), True, "LgxTag not found in GetTagList")
 
     def test_response_class(self):
+        try: assert plcConfig.skip_test_response_class ; return
+        except: pass
         one_bool = comm.Read('BaseBool')
         self.assertEqual(
             isinstance(one_bool, Response),
@@ -373,6 +397,8 @@ class PylogixTests(unittest.TestCase):
             True, "Reponse class not found in Write")
 
     def test_program_list(self):
+        try: assert plcConfig.skip_test_program_list ; return
+        except: pass
         programs = comm.GetProgramsList()
         self.assertEqual(programs.Status, 'Success', programs.Status)
         self.assertEqual(
@@ -380,6 +406,8 @@ class PylogixTests(unittest.TestCase):
             True, "Reponse class not found in GetProgramsList")
 
     def test_program_tag_list(self):
+        try: assert plcConfig.skip_test_program_tag_list ; return
+        except: pass
         program_tags = comm.GetProgramTagList('Program:MainProgram')
         self.assertEqual(program_tags.Status, 'Success', program_tags.Status)
         self.assertEqual(
@@ -388,6 +416,13 @@ class PylogixTests(unittest.TestCase):
         self.assertEqual(
             isinstance(program_tags.Value[0], Tag),
             True, "LgxTag class not found in GetProgramTagList Value")
+
+    def test_micro_800(self):
+        try: assert plcConfig.skip_test_micro_899 ; return
+        except: pass
+        self.assertFalse(PLC().Micro800)
+        self.assertFalse(PLC(Micro800=False).Micro800)
+        self.assertTrue(PLC(Micro800=True).Micro800)
 
     def tearDown(self):
         comm.Close()

--- a/tests/PylogixTests.py
+++ b/tests/PylogixTests.py
@@ -298,17 +298,15 @@ class PylogixTests(unittest.TestCase):
         comm.ProcessorSlot = plcConfig.plc_slot
         comm.Micro800 = plcConfig.isMicro800
 
+    @unittest.skipIf(plcConfig.isMicro800,'for Micro800')
     def test_basic(self):
-        try: assert plcConfig.skip_test_basic ; return
-        except: pass
         self.basic_fixture()
         self.basic_array_fixture()
         self.basic_fixture('PROGRAM:MainProgram.p')
         self.basic_array_fixture('PROGRAM:MainProgram.p')
 
+    @unittest.skipIf(plcConfig.isMicro800,'for Micro800')
     def test_udt(self):
-        try: assert plcConfig.skip_test_udt ; return
-        except: pass
         self.udt_basic_fixture()
         self.udt_array_fixture_01()
         self.udt_array_fixture_02()
@@ -316,72 +314,61 @@ class PylogixTests(unittest.TestCase):
         self.udt_array_fixture_01('PROGRAM:MainProgram.p')
         self.udt_array_fixture_02('PROGRAM:MainProgram.p')
 
+    @unittest.skipIf(plcConfig.isMicro800, 'for Micro800')
     def test_combined(self):
-        try: assert plcConfig.skip_test_combined ; return
-        except: pass
         self.udt_combined_fixture()
         self.udt_combined_array_fixture()
         self.udt_combined_fixture('PROGRAM:MainProgram.p')
         self.udt_combined_array_fixture('PROGRAM:MainProgram.p')
 
+    @unittest.skipIf(plcConfig.isMicro800, 'for Micro800')
     def test_array(self):
-        try: assert plcConfig.skip_test_array ; return
-        except: pass
         self.read_array_fixture()
         self.read_array_fixture('PROGRAM:MainProgram.p')
 
+    @unittest.skipIf(plcConfig.isMicro800, 'for Micro800')
     def test_multi_read(self):
-        try: assert plcConfig.skip_test_multi_read ; return
-        except: pass
         tags = ['BaseDINT', 'BaseINT', 'BaseSTRING']
         self.multi_read_fixture(tags)
 
+    @unittest.skipIf(plcConfig.isMicro800, 'for Micro800')
     def test_bool_list(self):
-        try: assert plcConfig.skip_test_bool_list ; return
-        except: pass
         tags = self.bool_list_fixture(128)
         self.multi_read_fixture(tags)
 
     def test_discover(self):
-        try: assert plcConfig.skip_test_discover ; return
-        except: pass
         devices = comm.Discover()
         self.assertEqual(devices.Status, 'Success', devices.Status)
 
+    @unittest.skipIf(plcConfig.isMicro800,'for Micro800')
     def test_time(self):
-        try: assert plcConfig.skip_test_time ; return
-        except: pass
         comm.SetPLCTime()
         time = comm.GetPLCTime()
         self.assertEqual(time.Status, 'Success', time.Status)
 
     def test_get_tags(self):
-        try: assert plcConfig.skip_test_get_tags ; return
-        except: pass
         tags = comm.GetTagList()
         self.assertGreater(len(tags.Value), 1, tags.Status)
 
     def test_unexistent_tags(self):
-        try: assert plcConfig.skip_test_unexistent_tags ; return
-        except: pass
+        expected_msg = (plcConfig.isMicro800
+            and 'Path destination unknown'
+            or 'Path segment error'
+            )
         response = comm.Read('DumbTag')
         self.assertEqual(
-            response.Status, 'Path segment error', response.Status)
+            response.Status, expected_msg, response.Status)
         write_reponse = comm.Write('DumbTag', 10)
         self.assertEqual(
-            write_reponse.Status, 'Path segment error', write_reponse.Status)
+            write_reponse.Status, expected_msg, write_reponse.Status)
 
     def test_lgx_tag_class(self):
-        try: assert plcConfig.skip_test_lgx_tag_class ; return
-        except: pass
         tags = comm.GetTagList()
         self.assertEqual(
             isinstance(
                 tags.Value[0], Tag), True, "LgxTag not found in GetTagList")
 
     def test_response_class(self):
-        try: assert plcConfig.skip_test_response_class ; return
-        except: pass
         one_bool = comm.Read('BaseBool')
         self.assertEqual(
             isinstance(one_bool, Response),
@@ -396,18 +383,16 @@ class PylogixTests(unittest.TestCase):
             isinstance(bool_write, Response),
             True, "Reponse class not found in Write")
 
+    @unittest.skipIf(plcConfig.isMicro800,'for Micro800')
     def test_program_list(self):
-        try: assert plcConfig.skip_test_program_list ; return
-        except: pass
         programs = comm.GetProgramsList()
         self.assertEqual(programs.Status, 'Success', programs.Status)
         self.assertEqual(
             isinstance(programs, Response),
             True, "Reponse class not found in GetProgramsList")
 
+    @unittest.skipIf(plcConfig.isMicro800,'for Micro800')
     def test_program_tag_list(self):
-        try: assert plcConfig.skip_test_program_tag_list ; return
-        except: pass
         program_tags = comm.GetProgramTagList('Program:MainProgram')
         self.assertEqual(program_tags.Status, 'Success', program_tags.Status)
         self.assertEqual(
@@ -417,9 +402,7 @@ class PylogixTests(unittest.TestCase):
             isinstance(program_tags.Value[0], Tag),
             True, "LgxTag class not found in GetProgramTagList Value")
 
-    def test_micro_800(self):
-        try: assert plcConfig.skip_test_micro_899 ; return
-        except: pass
+    def test_micro_800_init(self):
         self.assertFalse(PLC().Micro800)
         self.assertFalse(PLC(Micro800=False).Micro800)
         self.assertTrue(PLC(Micro800=True).Micro800)

--- a/tests/PylogixTests.py
+++ b/tests/PylogixTests.py
@@ -358,9 +358,9 @@ class PylogixTests(unittest.TestCase):
         response = comm.Read('DumbTag')
         self.assertEqual(
             response.Status, expected_msg, response.Status)
-        write_reponse = comm.Write('DumbTag', 10)
+        write_response = comm.Write('DumbTag', 10)
         self.assertEqual(
-            write_reponse.Status, expected_msg, write_reponse.Status)
+            write_response.Status, expected_msg, write_response.Status)
 
     def test_lgx_tag_class(self):
         tags = comm.GetTagList()

--- a/tests/README.md
+++ b/tests/README.md
@@ -74,7 +74,7 @@ These are default functions from unittest, they will run before each test.
 
 ## Setup test configuration
 
-I've added a `.gitignore` entry for plc configurations in order to avoid having to keep discarding ip, slot changes inside pylogixTests.py.
+I've added a `.gitignore` entry for plc configurations in order to avoid having to keep discarding ip, slot changes inside pylogixTests.py.  See the sample file plcConfig.py.template instead.
 
 Inside the tests folder create a file `plcConfig.py`, then copy and paste below variables:
 
@@ -83,6 +83,14 @@ plc_ip = '192.168.0.26'
 plc_slot = 1
 isMicro800 = False
 ```
+
+### Setup to skip particular tests
+
+See comments in file plcConfig.py.template.  Summary: add a line like this
+
+    skip_test_to_skip = True
+
+to skip the "test_to_skip" test;
 
 ## Setting up an RSLogix 5000 Project
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -74,7 +74,7 @@ These are default functions from unittest, they will run before each test.
 
 ## Setup test configuration
 
-I've added a `.gitignore` entry for plc configurations in order to avoid having to keep discarding ip, slot changes inside pylogixTests.py.  See the sample file plcConfig.py.template instead.
+I've added a `.gitignore` entry for plc configurations in order to avoid having to keep discarding ip, slot changes inside pylogixTests.py.
 
 Inside the tests folder create a file `plcConfig.py`, then copy and paste below variables:
 
@@ -84,13 +84,7 @@ plc_slot = 1
 isMicro800 = False
 ```
 
-### Setup to skip particular tests
-
-See comments in file plcConfig.py.template.  Summary: add a line like this
-
-    skip_test_to_skip = True
-
-to skip the "test_to_skip" test;
+See the sample file plcConfig.py.template.
 
 ## Setting up an RSLogix 5000 Project
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -88,7 +88,7 @@ See the sample file plcConfig.py.template.
 
 ## Setting up an RSLogix 5000 Project
 
-Due to the versioning system of Rockwell it is difficult to provide one project for all CLX, and Compactlogix controllers. (Will need someone with an micro800 to do a repeatable test setup as I don't have one of those laying around)
+Due to the versioning system of Rockwell it is difficult to provide one project for all CLX, and Compactlogix controllers. (Will need someone with a Micro800 to do a repeatable test setup as I don't have one of those laying around)
 
 (Files are in the clx_setup folder)
 

--- a/tests/plcConfig.py.template
+++ b/tests/plcConfig.py.template
@@ -1,0 +1,26 @@
+plc_ip = 'a.b.c.d'
+plc_slot = 0
+isMicro800 = False
+
+########################################################################
+"""
+### Copy any of these outside the triple-quotes to skip that test
+### E.g. to skip the test_basic test, put a line containg
+### [skip_test_basic = True] before the line with 72 hashes (#s) above
+
+skip_test_basic = True
+skip_test_udt = True
+skip_test_combined = True
+skip_test_array = True
+skip_test_multi_read = True
+skip_test_bool_list = True
+skip_test_discover = True
+skip_test_time = True
+skip_test_get_tags = True
+skip_test_unexistent_tags = True
+skip_test_lgx_tag_class = True
+skip_test_response_class = True
+skip_test_program_list = True
+skip_test_program_tag_list = True
+skip_test_micro_800 = True
+"""

--- a/tests/plcConfig.py.template
+++ b/tests/plcConfig.py.template
@@ -1,26 +1,3 @@
-plc_ip = 'a.b.c.d'
+plc_ip = '192.168.1.10'
 plc_slot = 0
 isMicro800 = False
-
-########################################################################
-"""
-### Copy any of these outside the triple-quotes to skip that test
-### E.g. to skip the test_basic test, put a line containg
-### [skip_test_basic = True] before the line with 72 hashes (#s) above
-
-skip_test_basic = True
-skip_test_udt = True
-skip_test_combined = True
-skip_test_array = True
-skip_test_multi_read = True
-skip_test_bool_list = True
-skip_test_discover = True
-skip_test_time = True
-skip_test_get_tags = True
-skip_test_unexistent_tags = True
-skip_test_lgx_tag_class = True
-skip_test_response_class = True
-skip_test_program_list = True
-skip_test_program_tag_list = True
-skip_test_micro_800 = True
-"""


### PR DESCRIPTION
## Short description of change

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **docs/CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read **tests/README.md**.
- [x] I have added tests to cover my changes.
- [?] All new and existing tests passed.

## What is the change?

1) Add **,Micro800=False** keyword to pylogix.PLC class, so Micro800 users can create the class within the single instantiation call and not require a subsequent **comm,Micro800=True** statement.

1.1) I used the **kwargs approach because it makes it easier down the road to do the same thing for other attributes of class pylogix.PLC, but I am not commited to it.

2) Add a technique to skip selected tests (maybe this exists in unittest already?).
2.1) Update tests/README.md
2.2) Add sample tests/plcConfig.py.template

## What does it fix/add?

See above.

## Test Configuration

No change, but the new code is tested.

- PLC Model
- PLC Firmware
- pylogix version
- python version
- OS type and version
