### PR TITLE
Fix a typo

### DIFF
--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -315,7 +315,7 @@ length, pylogix will simply use the number of values in the list.
 from pylogix import PLC
 with PLC("192.168.1.9") as comm:
     values = [123, 456, 789]
-    ret = comm.Read("MyDintArray[0]", values)
+    ret = comm.Write("MyDintArray[0]", values)
     print(ret.TagName, ret.Value, ret.Status)
 ```
 result:


### PR DESCRIPTION
In section of write a list of value, change 'Read' to 'Write'

