### PR TITLE
Fix DeviceType return

### DIFF
--- a/pylogix/lgx_device.py
+++ b/pylogix/lgx_device.py
@@ -110,7 +110,7 @@ class Device(object):
         resp.Vendor = Device.get_vendor(resp.VendorID)
 
         resp.DeviceID = unpack_from('<H', data, 50)[0]
-        resp.Device = Device.get_device(resp.DeviceID)
+        resp.DeviceType = Device.get_device(resp.DeviceID)
 
         resp.ProductCode = unpack_from('<H', data, 52)[0]
         major = unpack_from('<B', data, 54)[0]


### PR DESCRIPTION
## Short description of change
Fixes Issue#216. Device.get_device was originally writing to resp.Device instead of resp.DeviceType 
 
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **docs/CONTRIBUTING.md** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read **tests/README.md**.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## What does it fix/add?
Fixes the getDeviceProperties and getModuleProperties methods which were originally returning "None" for device type. 