### PR TITLE
Make Pylogix Port configurable

### DIFF
--- a/pylogix/eip.py
+++ b/pylogix/eip.py
@@ -33,11 +33,12 @@ from struct import pack, unpack_from
 # noinspection PyMethodMayBeStatic
 class PLC(object):
 
-    def __init__(self, ip_address="", slot=0, timeout=5.0, Micro800=False):
+    def __init__(self, ip_address="", port=44818, slot=0, timeout=5.0, Micro800=False):
         """
         Initialize our parameters
         """
         self.IPAddress = ip_address
+        self.Port = port
         self.ProcessorSlot = slot
         self.SocketTimeout = timeout
         self.Micro800 = Micro800

--- a/pylogix/eip.py
+++ b/pylogix/eip.py
@@ -33,7 +33,7 @@ from struct import pack, unpack_from
 # noinspection PyMethodMayBeStatic
 class PLC(object):
 
-    def __init__(self, ip_address="", port=44818, slot=0, timeout=5.0, Micro800=False):
+    def __init__(self, ip_address="", slot=0, timeout=5.0, Micro800=False, port=44818):
         """
         Initialize our parameters
         """

--- a/pylogix/lgx_comm.py
+++ b/pylogix/lgx_comm.py
@@ -26,7 +26,6 @@ class Connection(object):
     def __init__(self, parent):
         self.parent = parent
 
-        self.Port = 44818
         self.ConnectionSize = None  # Default to try Large, then Small Fwd Open.
         self.Socket = socket.socket()
         self.SocketConnected = False
@@ -92,7 +91,7 @@ class Connection(object):
                 pass
             self.Socket = socket.socket()
             self.Socket.settimeout(self.parent.SocketTimeout)
-            self.Socket.connect((self.parent.IPAddress, self.Port))
+            self.Socket.connect((self.parent.IPAddress, self.parent.Port))
         except socket.error as e:
             self.SocketConnected = False
             self._sequence_counter = 1
@@ -554,7 +553,7 @@ class Connection(object):
 
         return connection_path
 
-    def discover(self, parse_procedural_parameter):
+    def discover(self, parse_procedural_parameter, port=44818):
         """
         Discover devices on the network, similar to the RSLinx
         Ethernet I/P driver
@@ -574,7 +573,7 @@ class Connection(object):
                 s.settimeout(0.5)
                 s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
                 s.bind((ip[4][0], 0))
-                s.sendto(request, ('255.255.255.255', 44818))
+                s.sendto(request, ('255.255.255.255', port))
                 try:
                     while True:
                         ret = s.recv(4096)
@@ -597,7 +596,7 @@ class Connection(object):
             s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             s.settimeout(0.5)
             s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-            s.sendto(request, ('255.255.255.255', 44818))
+            s.sendto(request, ('255.255.255.255', port))
             try:
                 while True:
                     ret = s.recv(4096)

--- a/pylogix/lgx_comm.py
+++ b/pylogix/lgx_comm.py
@@ -553,7 +553,7 @@ class Connection(object):
 
         return connection_path
 
-    def discover(self, parse_procedural_parameter, port=44818):
+    def discover(self, parse_procedural_parameter):
         """
         Discover devices on the network, similar to the RSLinx
         Ethernet I/P driver
@@ -573,7 +573,7 @@ class Connection(object):
                 s.settimeout(0.5)
                 s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
                 s.bind((ip[4][0], 0))
-                s.sendto(request, ('255.255.255.255', port))
+                s.sendto(request, ('255.255.255.255', self.parent.Port))
                 try:
                     while True:
                         ret = s.recv(4096)
@@ -596,7 +596,7 @@ class Connection(object):
             s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             s.settimeout(0.5)
             s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-            s.sendto(request, ('255.255.255.255', port))
+            s.sendto(request, ('255.255.255.255', self.parent.Port))
             try:
                 while True:
                     ret = s.recv(4096)


### PR DESCRIPTION
## Short description of change

Prior to this PR, pylogix port is hardcoded to 44818. While this is understandable, since the port for the protocol defaults to 44818, we can make it default to 44818 but also configurable at the same time.

NOTE: not tested, documentation not added yet 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **docs/CONTRIBUTING.md** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read **tests/README.md**.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## What is the change?

add Port paramter in PLC class that defaults to 44818, but can be configured

## What does it fix/add?

make pylogix port configurable

## Test Configuration

- PLC Model
- PLC Firmware
- pylogix version
- python version
- OS type and version
