### PR TITLE
truncate strings

### DIFF
--- a/pylogix/eip.py
+++ b/pylogix/eip.py
@@ -77,9 +77,6 @@ class PLC(object):
                          0xd7: (8, "TIME", '<Q'),
                          0xda: (1, "STRING", '<B'),
                          0xdf: (8, "LTIME", '<Q')}
-        self.StringTypes = [0xa0,
-                            0xd0,
-                            0xda]
 
     @property
     def ConnectionSize(self):
@@ -484,10 +481,6 @@ class PLC(object):
         if not isinstance(value, (list, tuple)):
             value = [value]
 
-        # limit string size to 82 characters
-        if data_type in self.StringTypes:
-            value[0] = value[0][:82]
-
         # format the values
         for v in value:
             write_data.append(v)
@@ -541,7 +534,7 @@ class PLC(object):
         header = self._build_multi_service_header()
 
         write_values = []
-        for i, wd in enumerate(write_data):
+        for wd in write_data:
 
             tag_name, base_tag, index = parse_tag_name(wd[0])
 
@@ -595,10 +588,6 @@ class PLC(object):
                     service_segments.extend(temp_segments)
             else:
                 ioi = self._build_ioi(tag_name, data_type)
-                # limit string size to 82 characters
-                if data_type in self.StringTypes:
-                    value[0] = value[0][:82]
-                    write_data[i] = (wd[0], value)
                 write_service = self._add_write_service(ioi, value, data_type)
                 write_values.append((wd[0], value))
                 next_request_size = service_segment_size + rsp_tag_size + 2

--- a/pylogix/eip.py
+++ b/pylogix/eip.py
@@ -77,6 +77,9 @@ class PLC(object):
                          0xd7: (8, "TIME", '<Q'),
                          0xda: (1, "STRING", '<B'),
                          0xdf: (8, "LTIME", '<Q')}
+        self.StringTypes = [0xa0,
+                            0xd0,
+                            0xda]
 
     @property
     def ConnectionSize(self):
@@ -481,6 +484,10 @@ class PLC(object):
         if not isinstance(value, (list, tuple)):
             value = [value]
 
+        # limit string size to 82 characters
+        if data_type in self.StringTypes:
+            value[0] = value[0][:82]
+
         # format the values
         for v in value:
             write_data.append(v)
@@ -534,7 +541,7 @@ class PLC(object):
         header = self._build_multi_service_header()
 
         write_values = []
-        for wd in write_data:
+        for i, wd in enumerate(write_data):
 
             tag_name, base_tag, index = parse_tag_name(wd[0])
 
@@ -588,6 +595,10 @@ class PLC(object):
                     service_segments.extend(temp_segments)
             else:
                 ioi = self._build_ioi(tag_name, data_type)
+                # limit string size to 82 characters
+                if data_type in self.StringTypes:
+                    value[0] = value[0][:82]
+                    write_data[i] = (wd[0], value)
                 write_service = self._add_write_service(ioi, value, data_type)
                 write_values.append((wd[0], value))
                 next_request_size = service_segment_size + rsp_tag_size + 2

--- a/pylogix/eip.py
+++ b/pylogix/eip.py
@@ -1569,6 +1569,7 @@ class PLC(object):
         String for Compact/Control Logix
         """
         work = []
+        string = string[:82]
         temp = pack('<I', len(string)).decode(self.StringEncoding)
         for char in temp:
             work.append(ord(char))


### PR DESCRIPTION
### Issue:
Strings were being written but not read correctly due to differences in format specifiers for multi-write strings (packed four bytes '<I') and unpacking them (unpacked single byte '<B'). Even without the dissonance, both formats could write more than 82 characters and could result in a 'UnicodeDecodeError.'

### Troubleshooting Efforts:
- The observed data type of the strings was 0xa0, which is a struct. I am unsure of how to intentionally define this data type in Studio5000 and would have expected _parse_multi_read() to have unpacked type 0xda, string, from the stripped data. This is why a list of applicable string types was made.

- I tested custom string data types with longer character limits, but they returned an "Unknown error 255" in the response status. The Micro800 character limit is defined at 255, but its ASCII instructions have limits at 82 characters. I do not have access to a Micro800 currently for runtime testing.

- I attempted to find indications of the defined string character limit in the data from _parse_multi_read() but had no success.

### Other Proposed Solution:
- One approach could be to simply truncate the value at _make_standard_string(). However, this will not accurately reflect what was actually written in the response value.

### Reference:
- Here's Studio5000 info on strings. Page 13 shows how longer string can be created. [Link to documentation.](https://literature.rockwellautomation.com/idc/groups/literature/documents/pm/1756-pm013_-en-p.pdf)

### Open ended:
- I was not able to answer how the plc was holding onto the invalid string. In Studio5000 the monitored value displayed was truncated in this fashion already, but read as the full value written. I would have liked to power cycle the plc when in this state to see if the full value is held in the cache and the plc will construct the truncated value on power up.